### PR TITLE
feat: add whenData function

### DIFF
--- a/lib/src/process_value.dart
+++ b/lib/src/process_value.dart
@@ -22,7 +22,10 @@ sealed class ProcessValue<T> {
 
   /// Tries to map this [ProcessValue] to another [ProcessValue] using the
   /// provided [mapper] function.
-  ProcessValue<R> mapData<R>(R Function(T value) mapper) {
+  ///
+  /// Forwards [ProcessLoading] and [ProcessError] values. If an error occurs
+  /// in the [mapper] function, a [ProcessError] is returned.
+  ProcessValue<R> whenData<R>(R Function(T value) mapper) {
     switch (this) {
       case (ProcessData(:final value)):
         try {

--- a/lib/src/process_value.dart
+++ b/lib/src/process_value.dart
@@ -19,6 +19,23 @@ sealed class ProcessValue<T> {
   /// {@macro process_error}
   const factory ProcessValue.error(Object error, {StackTrace? stackTrace}) =
       ProcessError<T>;
+
+  /// Tries to map this [ProcessValue] to another [ProcessValue] using the
+  /// provided [mapper] function.
+  ProcessValue<R> mapData<R>(R Function(T value) mapper) {
+    switch (this) {
+      case (ProcessData(:final value)):
+        try {
+          return ProcessValue.data(mapper(value));
+        } catch (e, s) {
+          return ProcessValue.error(e, stackTrace: s);
+        }
+      case (ProcessLoading(:final progress)):
+        return ProcessLoading(progress);
+      case (ProcessError(:final error, :final stackTrace)):
+        return ProcessValue.error(error, stackTrace: stackTrace);
+    }
+  }
 }
 
 /// {@template process_data}

--- a/test/src/process_value_test.dart
+++ b/test/src/process_value_test.dart
@@ -36,6 +36,33 @@ void main() {
         expect(ProcessValue<int>.error("oops"), ProcessError<int>("oops"));
       });
     });
+
+    group("mapData", () {
+      test("maps value correctly", () async {
+        final sut = ProcessData(42);
+        final result = sut.mapData((value) => value.toString());
+        expect(result, ProcessData("42"));
+      });
+      test("returns error when mapping fails", () async {
+        final sut = ProcessData("fourtytwo");
+        final result = sut.mapData(int.parse);
+        expect(
+          result,
+          // ignore: inference_failure_on_untyped_parameter
+          (r) => r is ProcessError<int> && r.error is FormatException,
+        );
+      });
+      test("forwards progress", () async {
+        final sut = ProcessValue<int>.loading(0.5);
+        final result = sut.mapData((value) => value.toString());
+        expect(result, ProcessLoading<String>(0.5));
+      });
+      test("forwards error", () async {
+        final sut = ProcessValue<int>.error("oops");
+        final result = sut.mapData((value) => value.toString());
+        expect(result, (r) => r is ProcessError<String> && r.error == "oops");
+      });
+    });
   });
   group("ProcessData", () {
     test("value equality", () async {

--- a/test/src/process_value_test.dart
+++ b/test/src/process_value_test.dart
@@ -37,15 +37,15 @@ void main() {
       });
     });
 
-    group("mapData", () {
+    group("whenData", () {
       test("maps value correctly", () async {
         final sut = ProcessData(42);
-        final result = sut.mapData((value) => value.toString());
+        final result = sut.whenData((value) => value.toString());
         expect(result, ProcessData("42"));
       });
       test("returns error when mapping fails", () async {
         final sut = ProcessData("fourtytwo");
-        final result = sut.mapData(int.parse);
+        final result = sut.whenData(int.parse);
         expect(
           result,
           // ignore: inference_failure_on_untyped_parameter
@@ -54,12 +54,13 @@ void main() {
       });
       test("forwards progress", () async {
         final sut = ProcessValue<int>.loading(0.5);
-        final result = sut.mapData((value) => value.toString());
+        final result = sut.whenData((value) => value.toString());
         expect(result, ProcessLoading<String>(0.5));
       });
       test("forwards error", () async {
         final sut = ProcessValue<int>.error("oops");
-        final result = sut.mapData((value) => value.toString());
+        final result = sut.whenData((value) => value.toString());
+        // ignore: inference_failure_on_untyped_parameter
         expect(result, (r) => r is ProcessError<String> && r.error == "oops");
       });
     });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Adds a `mapData()` function, similar to `Future.then` to allow "unwrapping" a `ProcessValue` into another `ProcessValue` when it's done, but forwarding progress or errors